### PR TITLE
Fixed Kublet IP's and added new Flannel yml.

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -15,6 +15,7 @@ Vagrant.configure("2") do |config|
     for p in [:virtualbox, :libvirt] do
       master.vm.provider p do |provider|
         provider.memory = 2048
+        provider.cpus = 2
       end
     end
   end
@@ -25,6 +26,7 @@ Vagrant.configure("2") do |config|
     for p in [:virtualbox, :libvirt] do
       node1.vm.provider p do |provider|
         provider.memory = 2048
+        provider.cpus = 2
       end
     end
   end
@@ -35,6 +37,7 @@ Vagrant.configure("2") do |config|
     for p in [:virtualbox, :libvirt] do
       node2.vm.provider p do |provider|
         provider.memory = 2048
+        provider.cpus = 2
       end
     end
   end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -26,7 +26,6 @@ Vagrant.configure("2") do |config|
     for p in [:virtualbox, :libvirt] do
       node1.vm.provider p do |provider|
         provider.memory = 2048
-        provider.cpus = 2
       end
     end
   end
@@ -37,7 +36,6 @@ Vagrant.configure("2") do |config|
     for p in [:virtualbox, :libvirt] do
       node2.vm.provider p do |provider|
         provider.memory = 2048
-        provider.cpus = 2
       end
     end
   end

--- a/build_cluster.sh
+++ b/build_cluster.sh
@@ -3,6 +3,21 @@ set -x
 
 vagrant up
 
+#Fix Kubelet IP on Master
+vagrant ssh master -c "echo 'Environment=\"KUBELET_EXTRA_ARGS=--node-ip=192.168.33.20\"' | sudo tee --append  /etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+vagrant ssh master -c "sudo systemctl daemon-reload"
+vagrant ssh master -c "sudo systemctl restart kubelet.service"
+
+#Fix Kubelet IP on Node1
+vagrant ssh node1 -c "echo 'Environment=\"KUBELET_EXTRA_ARGS=--node-ip=192.168.33.21\"' | sudo tee --append  /etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+vagrant ssh node1 -c "sudo systemctl daemon-reload"
+vagrant ssh node1 -c "sudo systemctl restart kubelet.service"
+
+#Fix Kubelet IP on Node2
+vagrant ssh node2 -c "echo 'Environment=\"KUBELET_EXTRA_ARGS=--node-ip=192.168.33.22\"' | sudo tee --append  /etc/systemd/system/kubelet.service.d/10-kubeadm.conf"
+vagrant ssh node2 -c "sudo systemctl daemon-reload"
+vagrant ssh node2 -c "sudo systemctl restart kubelet.service"
+
 join_cmd=$(vagrant ssh master -c "sudo kubeadm token create --print-join-command")
 
 vagrant ssh node1 -c "sudo ${join_cmd}"

--- a/kube-flannel.yml
+++ b/kube-flannel.yml
@@ -1,0 +1,160 @@
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - pods
+    verbs:
+      - get
+  - apiGroups:
+      - ""
+    resources:
+      - nodes
+    verbs:
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - nodes/status
+    verbs:
+      - patch
+---
+kind: ClusterRoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: flannel
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: flannel
+subjects:
+- kind: ServiceAccount
+  name: flannel
+  namespace: kube-system
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: flannel
+  namespace: kube-system
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: kube-flannel-cfg
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+data:
+  cni-conf.json: |
+    {
+      "name": "cbr0",
+      "plugins": [
+        {
+          "type": "flannel",
+          "delegate": {
+            "hairpinMode": true,
+            "isDefaultGateway": true
+          }
+        },
+        {
+          "type": "portmap",
+          "capabilities": {
+            "portMappings": true
+          }
+        }
+      ]
+    }
+  net-conf.json: |
+    {
+      "Network": "10.244.0.0/16",
+      "Backend": {
+        "Type": "vxlan"
+      }
+    }
+---
+apiVersion: extensions/v1beta1
+kind: DaemonSet
+metadata:
+  name: kube-flannel-ds
+  namespace: kube-system
+  labels:
+    tier: node
+    app: flannel
+spec:
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: flannel
+    spec:
+      hostNetwork: true
+      nodeSelector:
+        beta.kubernetes.io/arch: amd64
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      serviceAccountName: flannel
+      initContainers:
+      - name: install-cni
+        image: quay.io/coreos/flannel:v0.10.0-amd64
+        command:
+        - cp
+        args:
+        - -f
+        - /etc/kube-flannel/cni-conf.json
+        - /etc/cni/net.d/10-flannel.conflist
+        volumeMounts:
+        - name: cni
+          mountPath: /etc/cni/net.d
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      containers:
+      - name: kube-flannel
+        image: quay.io/coreos/flannel:v0.10.0-amd64
+        command:
+        - /opt/bin/flanneld
+        args:
+        - --ip-masq
+        - --kube-subnet-mgr
+        - --iface=eth1
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "50Mi"
+          limits:
+            cpu: "100m"
+            memory: "50Mi"
+        securityContext:
+          privileged: true
+        env:
+        - name: POD_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.name
+        - name: POD_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: run
+          mountPath: /run
+        - name: flannel-cfg
+          mountPath: /etc/kube-flannel/
+      volumes:
+        - name: run
+          hostPath:
+            path: /run
+        - name: cni
+          hostPath:
+            path: /etc/cni/net.d
+        - name: flannel-cfg
+          configMap:
+            name: kube-flannel-cfg

--- a/provision/master_init.sh
+++ b/provision/master_init.sh
@@ -7,8 +7,5 @@ mkdir -p $HOME/.kube
 sudo cp -i /etc/kubernetes/admin.conf $HOME/.kube/config
 sudo chown $(id -u):$(id -g) $HOME/.kube/config
 
-FLANNEL_VERSION=v0.9.1
-curl -o /tmp/kube-flannel.yml https://raw.githubusercontent.com/coreos/flannel/$FLANNEL_VERSION/Documentation/kube-flannel.yml
-sed -i.bak 's|"/opt/bin/flanneld",|"/opt/bin/flanneld", "--iface=eth1",|' /tmp/kube-flannel.yml
-kubectl apply -f /tmp/kube-flannel.yml
+kubectl apply -f https://raw.githubusercontent.com/IshwarKanse/cka_lab/master/kube-flannel.yml
 echo 'source <(kubectl completion bash)' >> $HOME/.bashrc


### PR DESCRIPTION
In a Vagrant env, we have to specify the eth1 ip to use for Kublet. 
https://medium.com/@joatmon08/playing-with-kubeadm-in-vagrant-machines-part-2-bac431095706

Also I've updated the Flannel yml. The old one was having issues with Kubernetes 1.10. 